### PR TITLE
Refactor code driving menu options

### DIFF
--- a/Loop/Game.cs
+++ b/Loop/Game.cs
@@ -33,7 +33,6 @@ namespace Casino.Loop
         public void PlaySlots()
         {
             _menuHandler.RunSlotsMenu(this);
-            DisplaySlotMenu();
         }
 
         public void PullLever()
@@ -45,52 +44,6 @@ namespace Casino.Loop
                 slots.SpinReels();
             }
 
-        }
-        private void DisplaySlotMenu()
-        {
-            bool running = true;
-            do
-            {
-                switch (_menuHandler.GetSlotsMenuSelection())
-                {
-                        case (int)SlotsMenuOptions.PLACE_BET:
-                            Console.WriteLine("Going to place bet;");
-                            PullLever();
-                            break;
-                        case (int)SlotsMenuOptions.CHECK_STATS:
-                            Console.WriteLine("Checking stats");
-                            DisplayStatsMenu();
-                            break;
-                        case (int)SlotsMenuOptions.VIEW_PAYOUT:
-                            Console.WriteLine("Viewing payout...");
-                            break;
-                        case (int)SlotsMenuOptions.CHANGE_BET:
-                            Console.WriteLine("Changing Bet");
-                            break;
-                        case (int)SlotsMenuOptions.AUTO_SPIN:
-                            Console.WriteLine("Auto spin");
-                            break;
-                        case (int)SlotsMenuOptions.EXIT_TO_MAIN_MENU:
-                            running = false;
-                            break;
-                }
-            } while (running);
-        }
-        private void DisplayStatsMenu()
-        {
-            bool displayMenu = true;
-            do
-            {
-                switch (_menuHandler.GetStatsMenuSelection())
-                {
-                    case (int)StatsMenuOptions.RETURN_TO_GAME:
-                        displayMenu = false;
-                        break;
-                    default:
-                        Console.WriteLine("Error: invalid menu input.");
-                        break;
-                }
-            } while (displayMenu);
         }
     }
 }

--- a/Loop/Game.cs
+++ b/Loop/Game.cs
@@ -25,39 +25,25 @@ namespace Casino.Loop
         public void Run()
         {
             bool running = true;
-            do
+            while(running)
             {
-
-                switch (this._menuHandler.GetMainMenuSelection())
-                {
-                    case (int)MainMenuOptions.SOLITARE:
-                        Console.WriteLine("ToDo: make Solitare game.");
-                        break;
-                    case (int)MainMenuOptions.SLOTS:
-                        Console.WriteLine("going to play slots.");
-                        PlaySlots();
-                        break;
-                    case (int)MainMenuOptions.EXIT:
-                        Console.WriteLine("Exiting program.");
-                        running = false;
-                        break;
-                }
-            } while (running);
+                running = _menuHandler.RunMainMenu(this);
+            }
         }
-        void PlaySlots()
+        public void PlaySlots()
         {
+            _menuHandler.RunSlotsMenu(this);
             DisplaySlotMenu();
         }
 
-        private void SlotLoop()
+        public void PullLever()
         {
             SlotMachine slots = new SlotMachine();
-            bool bankEmpty = this._player.playerBankEmpty();
-            do
+            while (!_player.playerBankEmpty())
             {
-                this._player.deductBet(slots.placeBet(this._player));
+                _player.deductBet(slots.placeBet(_player));
                 slots.SpinReels();
-            } while (!this._player.playerBankEmpty());
+            }
 
         }
         private void DisplaySlotMenu()
@@ -69,7 +55,7 @@ namespace Casino.Loop
                 {
                         case (int)SlotsMenuOptions.PLACE_BET:
                             Console.WriteLine("Going to place bet;");
-                            SlotLoop();
+                            PullLever();
                             break;
                         case (int)SlotsMenuOptions.CHECK_STATS:
                             Console.WriteLine("Checking stats");

--- a/UI/Handlers/MenuHandler.cs
+++ b/UI/Handlers/MenuHandler.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿using Casino.Loop;
+using Casino.UI.Menus;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -36,5 +38,64 @@ namespace Casino.UI.Handlers
             return _statsMenu.GetUserSelection();
         }
 
+        public bool RunMainMenu(Game game)
+        {
+            switch (this.GetMainMenuSelection())
+            {
+                case (int)MainMenuOptions.SOLITARE:
+                    Console.WriteLine("ToDo: make Solitare game.");
+                    return true;
+                case (int)MainMenuOptions.SLOTS:
+                    Console.WriteLine("going to play slots.");
+                    game.PlaySlots();
+                    return true;
+                case (int)MainMenuOptions.EXIT:
+                    Console.WriteLine("Exiting program.");
+                    return false;
+                default:
+                    Console.WriteLine("Invalid selection.");
+                    return true;
+            }
+        }
+        public void RunSlotsMenu(Game game)
+        {
+            bool running = true;
+            while (running)
+            {
+                switch (this.GetSlotsMenuSelection())
+                {
+                    case (int)SlotsMenuOptions.PLACE_BET:
+                        Console.WriteLine("Going to place bet;");
+                        game.PullLever();
+                        break;
+                    case (int)SlotsMenuOptions.CHECK_STATS:
+                        Console.WriteLine("Checking stats");
+                        game.DisplayStatsMenu();
+                        break;
+                    case (int)SlotsMenuOptions.VIEW_PAYOUT:
+                        Console.WriteLine("Viewing payout...");
+                        break;
+                    case (int)SlotsMenuOptions.CHANGE_BET:
+                        Console.WriteLine("Changing Bet");
+                        break;
+                    case (int)SlotsMenuOptions.AUTO_SPIN:
+                        Console.WriteLine("Auto spin");
+                        break;
+                    case (int)SlotsMenuOptions.EXIT_TO_MAIN_MENU:
+                        running = false;
+                        break;
+                }
+            }
+        }
+        public void HandleStatsMenu()
+        {
+            while (true)
+            {
+                if(_statsMenu.GetUserSelection() == (int)StatsMenuOptions.RETURN_TO_GAME)
+                {
+                    break;
+                }
+            }
+        }
     }
 }

--- a/UI/Handlers/MenuHandler.cs
+++ b/UI/Handlers/MenuHandler.cs
@@ -21,7 +21,7 @@ namespace Casino.UI.Handlers
         private void InitializeMenus()
         {
             _mainMenu = new Menu("Casino", "Play Solitare", "Play Slots");
-            _slotsMenu = new Menu("Play Slots",false,"Place Bet", "View Payout Table", "Check Balance", "Change Bet Amount", "Auto-Spin", "Exit to Main Menu");
+            _slotsMenu = new Menu("Play Slots",false,"Place Bet", "View Payout Table", "Check Stats", "Change Bet Amount", "Auto-Spin", "Exit to Main Menu");
             _statsMenu = new Menu("Stats", false, "Return to Game");
         }
 

--- a/UI/Handlers/MenuHandler.cs
+++ b/UI/Handlers/MenuHandler.cs
@@ -70,7 +70,7 @@ namespace Casino.UI.Handlers
                         break;
                     case (int)SlotsMenuOptions.CHECK_STATS:
                         Console.WriteLine("Checking stats");
-                        game.DisplayStatsMenu();
+                        this.HandleStatsMenu();
                         break;
                     case (int)SlotsMenuOptions.VIEW_PAYOUT:
                         Console.WriteLine("Viewing payout...");


### PR DESCRIPTION
This PR places code that drives menus inside the menu handler class for better encapsulation.

This is necessary because prior to this, the code that handles the main menu display loop and input collection was inside the Game class, as was the code that displays the slots game main menu, and stats menu.

Moving that code into the Menu Handler hopefully makes code that is in the game class easier to read.