### PR TITLE
Better displaybet method

### DIFF
--- a/Loop/SlotsGame.cs
+++ b/Loop/SlotsGame.cs
@@ -61,9 +61,9 @@ namespace Casino.Loop
         {
             return Util.Input.GetNumberFromInput("Enter your bet: ");
         }
-        public String DisplayBet()
+        public void DisplayBet()
         {
-            return $"Current bet: {Bet}";
+            Console.WriteLine($"Current bet: {Bet}");
         }
         public override string ToString()
         {

--- a/UI/Handlers/MenuHandler.cs
+++ b/UI/Handlers/MenuHandler.cs
@@ -67,7 +67,7 @@ namespace Casino.UI.Handlers
                     case (int)SlotsMenuOptions.PLACE_BET:
                         Console.WriteLine("Going to place bet;");
                         slotGame.Bet = slotGame.PromptForUserBet();
-                        Console.WriteLine(slotGame.DisplayBet());
+                        slotGame.DisplayBet();
                         break;
                     case (int)SlotsMenuOptions.CHECK_STATS:
                         Console.WriteLine("Checking stats");


### PR DESCRIPTION
This PR changes the method return type of SlotGame.DisplayBet from void to string.

This is necessary to have better code readability within the slot menu where the handler calls this method after placing a bet.